### PR TITLE
fix(ci): remove minimal-versions check

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,23 +26,6 @@ jobs:
       # https://twitter.com/jonhoo/status/1571290371124260865
       - name: Run cargo test --locked
         run: cargo test --locked --all-features --all-targets
-  minimal:
-    runs-on: ubuntu-latest
-    name: ubuntu / stable / minimal-versions
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          submodules: true
-      - name: Install stable
-        uses: dtolnay/rust-toolchain@stable
-      - name: Install nightly for -Zminimal-versions
-        uses: dtolnay/rust-toolchain@nightly
-      - name: Run rustup default stable
-        run: rustup default stable
-      - name: Run cargo update -Zminimal-versions
-        run: cargo +nightly update -Zminimal-versions
-      - name: Run cargo test
-        run: cargo test --locked --all-features --all-targets
   os-check:
     runs-on: ${{ matrix.os }}
     name: ${{ matrix.os }} / stable


### PR DESCRIPTION
Since we are not a library we have our own dependencies specified in the Cargo.lock, so we don't need to check minimal-versions.